### PR TITLE
fix: 修复组合插件元素的时候插件元素消失的问题

### DIFF
--- a/src/pages/editor/core/layers/Group.tsx
+++ b/src/pages/editor/core/layers/Group.tsx
@@ -6,6 +6,7 @@ import useLayerBaseStyle from '../hooks/useLayerBaseStyle';
 
 import ImageLayer from './Image';
 import TextLayer from './Text';
+import exLayers from '@plugins/index';
 
 export default function GroupComp(props: LayerProps) {
   const layer = props.layer as GroupLayer;
@@ -113,6 +114,26 @@ export default function GroupComp(props: LayerProps) {
                 env={env}
               />
             );
+          default: {
+            const exLayer = exLayers.find(d => d.config.pid === layer.type);
+            if (exLayer) {
+              const ELayer = exLayer.Layer as any;
+              return (
+                <ELayer
+                  key={layer.id}
+                  hide={layer._hide}
+                  lock={layer._lock}
+                  dirty={layer._dirty}
+                  isChild={true}
+                  parent={groupBox}
+                  zIndex={99999 - i}
+                  layer={layer}
+                  store={store}
+                  env={env}
+                />
+              );
+            }
+          }
         }
         return null;
       })}


### PR DESCRIPTION
涉及文件 src/pages/editor/core/layers/Group.tsx

Reviewed-by: 技安 <echo_ai@foxmail.com> vx: Lee_coding
Refs: #3